### PR TITLE
Hamim23z Elasticsearch_Change1

### DIFF
--- a/vro/search/utils.py
+++ b/vro/search/utils.py
@@ -102,7 +102,7 @@ def create_docs():
         FROM certificates
             LEFT OUTER JOIN marriage_data AS marriage_data_1 ON certificates.id = marriage_data_1.certificate_id
         WHERE certificates.filename IS NOT NULL
-        GROUP BY certificates.id;
+        GROUP BY certificates.id limit 500000;
     """)
 
     count = 0

--- a/vro/templates/public/browse_all.html
+++ b/vro/templates/public/browse_all.html
@@ -1,5 +1,8 @@
-{% extends "base.html" %} {% block page_title %}Browse All{% endblock %} {%
-block content %}
+{% extends "base.html" %} 
+
+{% block page_title %}Browse All{% endblock %} 
+
+{%block content %}
 <section class="py-3">
   <div class="container">
     <div class="row matrix-gutter px-2 pb-2 justify-content-between">
@@ -18,30 +21,30 @@ block content %}
       role="form"
       id="browse-all-form"
     >
-      {{ form.year() }} {{ form.number() }} {{ form.last_name() }} {{
-      form.first_name() }} {{ form.page() }}
+      {{ form.year() }}
+      {{ form.number() }}
+      {{ form.last_name() }}
+      {{ form.first_name() }}
+      {{ form.page() }}
       <div class="section mx-2 mb-2">
         <div class="row py-1 pt-2">
           <div class="col-md center">
             <div class="form-group">
-              {{ form.certificate_type.label(class="control-label",
-              for="certificate_type") }} {{
-              form.certificate_type(class="form-control browse-all-select
-              mx-auto") }}
+              {{ form.certificate_type.label(class="control-label",for="certificate_type") }} 
+              {{ form.certificate_type(class="form-control browse-all-select mx-auto") }}
             </div>
           </div>
           <div class="col-md center">
             <div class="form-group">
-              {{ form.year_range.label(class="control-label", for="year_range")
-              }} {{ form.year_range(class="form-control browse-all-year-range
-              mx-auto", id="year-range", readonly=true ) }}
+              {{ form.year_range.label(class="control-label", for="year_range")}} 
+              {{ form.year_range(class="form-control browse-all-year-range mx-auto", id="year-range", readonly=true ) }}
             </div>
             <div id="browse-page-slider-range"></div>
           </div>
           <div class="col-md center">
             <div class="form-group">
-              {{ form.county.label(class="control-label", for="county") }} {{
-              form.county(class="form-control browse-all-select mx-auto") }}
+              {{ form.county.label(class="control-label", for="county") }} 
+              {{ form.county(class="form-control browse-all-select mx-auto") }}
             </div>
           </div>
         </div>
@@ -120,7 +123,6 @@ block content %}
           <span aria-hidden="true">&laquo;</span>
         </a>
       </li>
-      
       {% else %}
       <li class="page-item disabled">
         <span class="page-link">&laquo;</span>
@@ -128,7 +130,6 @@ block content %}
       {% endif %} {% set start = [page - 2, 1] | max %} {% set end = [start + 4,
       total_pages] | min %} {% set start = [end - 4, 1] | max %} {% if start > 1
       %}
-
       <li class="page-item">
         {% set query_params = request.args.copy() %} {% set _ =
         query_params.pop('page', None) %}
@@ -138,7 +139,6 @@ block content %}
           >1</a
         >
       </li>
-
       {% if start > 2 %}
       <li class="page-item disabled"><span class="page-link">...</span></li>
       {% endif %} {% endif %} {% for p in range(start, end + 1) %}
@@ -151,7 +151,6 @@ block content %}
           >{{ p }}</a
         >
       </li>
-
       {% endfor %} {% if end < total_pages %} {% if end < total_pages - 1 %}
       <li class="page-item disabled"><span class="page-link">...</span></li>
       {% endif %}
@@ -186,7 +185,6 @@ block content %}
   
   <h5 class="center pt-2">Showing page {{ page }}</h5>
   {% endif %}
-
 
   <!-- .container -->
 </section>

--- a/vro/templates/public/browse_all.html
+++ b/vro/templates/public/browse_all.html
@@ -1,123 +1,215 @@
-{% extends "base.html" %}
-
-{% block page_title %}Browse All{% endblock %}
-
-{% block content %}
+{% extends "base.html" %} {% block page_title %}Browse All{% endblock %} {%
+block content %}
 <section class="py-3">
-    <div class="container">
-        <div class="row matrix-gutter px-2 pb-2 justify-content-between">
-            {% if num_results != "0" %}
-            <div class="col-6"><h2>{{ num_results }} Vital Record Results</h2></div>
-            {% else %}
-            <div class="col-6"><h2>No Results</h2></div>
-            {% endif %}
-        </div>
-        <form class="col-lg" action="{{ url_for('public.browse_all') }}" method="get" role="form" id="browse-all-form">
-            {{ form.year() }}
-            {{ form.number() }}
-            {{ form.last_name() }}
-            {{ form.first_name() }}
-            {{ form.page() }}
-            <div class="section mx-2 mb-2">
-                <div class="row py-1 pt-2">
-                    <div class="col-md center">
-                        <div class="form-group">
-                            {{ form.certificate_type.label(class="control-label", for="certificate_type") }}
-                            {{ form.certificate_type(class="form-control browse-all-select mx-auto") }}
-                        </div>
-                    </div>
-                    <div class="col-md center">
-                        <div class="form-group">
-                            {{ form.year_range.label(class="control-label", for="year_range") }}
-                            {{ form.year_range(class="form-control browse-all-year-range mx-auto", id="year-range", readonly=true ) }}
-                        </div>
-                        <div id="browse-page-slider-range"></div>
-                    </div>
-                    <div class="col-md center">
-                        <div class="form-group">
-                            {{ form.county.label(class="control-label", for="county") }}
-                            {{ form.county(class="form-control browse-all-select mx-auto") }}
-                        </div>
-                    </div>
-                </div>
-                <div class="row text-center">
-                    <div class="col-lg align-self-center">
-                        <button class="btn btn-info">Update</button>
-                    </div>
-                </div>
-            </div>
-        </form>
-        {% if remove_filters %}
-            <div class="row">
-                <div class="col-lg">
-                    <hr>
-                </div>
-            </div>
-            <div class="row py-2">
-                <div class="col-lg">
-                    <small class="pr-2">Remove Filters:</small>
-                    {% for key, value in remove_filters.items() %}
-                        <span class="border border-light px-2 pt-1 pb-1 small"><b>{{ value[0] }}</b><a class="remove-filter" href="{{ value[1] }}" aria-label="Remove filter {{ value[0] }}">&nbsp;X&nbsp;</a></span>
-                    {% endfor %}
-                </div>
-            </div>
-        {% endif %}
-        <div class="row">
-            <div class="col-lg">
-                <hr>
-            </div>
-        </div>
-        {% if num_results != "0" %}
-        <div id="results">
-            {% include "public/_browse_all_results.html" %}
-        </div>
-        {% else %}
-        <div class="container">
-            <div class="row px-2 py-4">
-                <p class="large">There are no results for your search. Read our <a
-                        href="{{ url_for('public.search') }}">Search Tips</a> or see <a
-                        href="{{ url_for('public.digital_vital_records') }}">Digital Vital Records</a> for what you can find on this
-                    site.</p>
-                <p class="large">Please note that the "No Results" message is generated when there is not a digitized
-                    image associated with the search. Future versions of this application will return the certificate
-                    number (if found) along with instructions on how to view/order a copy of the certificate pending
-                    digitization.</p>
-            </div>
-        </div>
-        {% endif %}
+  <div class="container">
+    <div class="row matrix-gutter px-2 pb-2 justify-content-between">
+      {% if num_results != "0" %}
+      <div class="col-6">
+        <h2>{{ total_documents }} Vital Record Results</h2>
+      </div>
+      {% else %}
+      <div class="col-6"><h2>No Results</h2></div>
+      {% endif %}
     </div>
-
+    <form
+      class="col-lg"
+      action="{{ url_for('public.browse_all') }}"
+      method="get"
+      role="form"
+      id="browse-all-form"
+    >
+      {{ form.year() }} {{ form.number() }} {{ form.last_name() }} {{
+      form.first_name() }} {{ form.page() }}
+      <div class="section mx-2 mb-2">
+        <div class="row py-1 pt-2">
+          <div class="col-md center">
+            <div class="form-group">
+              {{ form.certificate_type.label(class="control-label",
+              for="certificate_type") }} {{
+              form.certificate_type(class="form-control browse-all-select
+              mx-auto") }}
+            </div>
+          </div>
+          <div class="col-md center">
+            <div class="form-group">
+              {{ form.year_range.label(class="control-label", for="year_range")
+              }} {{ form.year_range(class="form-control browse-all-year-range
+              mx-auto", id="year-range", readonly=true ) }}
+            </div>
+            <div id="browse-page-slider-range"></div>
+          </div>
+          <div class="col-md center">
+            <div class="form-group">
+              {{ form.county.label(class="control-label", for="county") }} {{
+              form.county(class="form-control browse-all-select mx-auto") }}
+            </div>
+          </div>
+        </div>
+        <div class="row text-center">
+          <div class="col-lg align-self-center">
+            <button class="btn btn-info">Update</button>
+          </div>
+        </div>
+      </div>
+    </form>
+    {% if remove_filters %}
+    <div class="row">
+      <div class="col-lg">
+        <hr />
+      </div>
+    </div>
+    <div class="row py-2">
+      <div class="col-lg">
+        <small class="pr-2">Remove Filters:</small>
+        {% for key, value in remove_filters.items() %}
+        <span class="border border-light px-2 pt-1 pb-1 small"
+          ><b>{{ value[0] }}</b
+          ><a
+            class="remove-filter"
+            href="{{ value[1] }}"
+            aria-label="Remove filter {{ value[0] }}"
+            >&nbsp;X&nbsp;</a
+          ></span
+        >
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+    <div class="row">
+      <div class="col-lg">
+        <hr />
+      </div>
+    </div>
     {% if num_results != "0" %}
-    <nav aria-label="Browse Results">
-        {{ pagination.links }}
-    </nav>
-
-    {% if pagination.total > 50 %}
-    <p class="center pt-2">Only the first 100 pages of results will display. Use filters to find relevant records.</p>
+    <div id="results">{% include "public/_browse_all_results.html" %}</div>
+    {% else %}
+    <div class="container">
+      <div class="row px-2 py-4">
+        <p class="large">
+          There are no results for your search. Read our
+          <a href="{{ url_for('public.search') }}">Search Tips</a> or see
+          <a href="{{ url_for('public.digital_vital_records') }}"
+            >Digital Vital Records</a
+          >
+          for what you can find on this site.
+        </p>
+        <p class="large">
+          Please note that the "No Results" message is generated when there is
+          not a digitized image associated with the search. Future versions of
+          this application will return the certificate number (if found) along
+          with instructions on how to view/order a copy of the certificate
+          pending digitization.
+        </p>
+      </div>
+    </div>
     {% endif %}
+  </div>
 
-    {% endif %}
-    <!-- .container -->
+  {% if num_results != "0" %}
+  <nav aria-label="Browse Results">
+    <ul class="pagination justify-content-center">
+      {% if has_prev %}
+      <li class="page-item">
+        {% set query_params = request.args.copy() %} {% set _ =
+        query_params.pop('page', None) %}
+        <a
+          class="page-link"
+          href="{{ url_for('public.browse_all', page=page-1, **query_params) }}"
+          aria-label="Previous"
+        >
+          <span aria-hidden="true">&laquo;</span>
+        </a>
+      </li>
+      
+      {% else %}
+      <li class="page-item disabled">
+        <span class="page-link">&laquo;</span>
+      </li
+      {% endif %} {% set start = [page - 2, 1] | max %} {% set end = [start + 4,
+      total_pages] | min %} {% set start = [end - 4, 1] | max %} {% if start > 1
+      %}
+
+      <li class="page-item">
+        {% set query_params = request.args.copy() %} {% set _ =
+        query_params.pop('page', None) %}
+        <a
+          class="page-link"
+          href="{{ url_for('public.browse_all', page=1, **query_params) }}"
+          >1</a
+        >
+      </li>
+
+      {% if start > 2 %}
+      <li class="page-item disabled"><span class="page-link">...</span></li>
+      {% endif %} {% endif %} {% for p in range(start, end + 1) %}
+      <li class="page-item {% if p == page %}active{% endif %}">
+        {% set query_params = request.args.copy() %} {% set _ =
+        query_params.pop('page', None) %}
+        <a
+          class="page-link"
+          href="{{ url_for('public.browse_all', page=p, **query_params) }}"
+          >{{ p }}</a
+        >
+      </li>
+
+      {% endfor %} {% if end < total_pages %} {% if end < total_pages - 1 %}
+      <li class="page-item disabled"><span class="page-link">...</span></li>
+      {% endif %}
+      <li class="page-item">
+        {% set query_params = request.args.copy() %} {% set _ =
+        query_params.pop('page', None) %}
+        <a
+          class="page-link"
+          href="{{ url_for('public.browse_all', page=total_pages, **query_params) }}"
+          >{{ total_pages }}</a
+        >
+      </li>
+      {% endif %} {% if has_next %}
+      <li class="page-item">
+        {% set query_params = request.args.copy() %} {% set _ =
+        query_params.pop('page', None) %}
+        <a
+          class="page-link"
+          href="{{ url_for('public.browse_all', page=page+1, **query_params) }}"
+          aria-label="Next"
+        >
+          <span aria-hidden="true">&raquo;</span>
+        </a>
+      </li>
+      {% else %}
+      <li class="page-item disabled">
+        <span class="page-link">&raquo;</span>
+      </li>
+      {% endif %}
+    </ul>
+  </nav>
+  
+  <h5 class="center pt-2">Showing page {{ page }}</h5>
+  {% endif %}
+
+
+  <!-- .container -->
 </section>
-{% endblock %}
-
-{% block js %}
+{% endblock %} {% block js %}
 <script src="{{ static_url_for('static', filename='js/public/pagination.js') }}"></script>
 <script>
-    "use strict";
+  "use strict";
 
-    $(function () {
-        $("#browse-page-slider-range").slider({
-            range: true,
-            min: parseInt("{{ year_range_min }}"),
-            max: parseInt("{{ year_range_max }}"),
-            values: ["{{ year_min_value }}", "{{ year_max_value }}"],
-            slide: function (event, ui) {
-                $("#year-range").val(ui.values[0] + " to " + ui.values[1]);
-            }
-        });
-        $("#year-range").val($("#browse-page-slider-range").slider("values", 0) +
-            " to " + $("#browse-page-slider-range").slider("values", 1));
+  $(function () {
+    $("#browse-page-slider-range").slider({
+      range: true,
+      min: parseInt("{{ year_range_min }}"),
+      max: parseInt("{{ year_range_max }}"),
+      values: ["{{ year_min_value }}", "{{ year_max_value }}"],
+      slide: function (event, ui) {
+        $("#year-range").val(ui.values[0] + " to " + ui.values[1]);
+      },
     });
+    $("#year-range").val(
+      $("#browse-page-slider-range").slider("values", 0) +
+        " to " +
+        $("#browse-page-slider-range").slider("values", 1)
+    );
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
Removed previous ElasticSearch method for pagination. Implemented, search_after parameter which allows users to now go post the 10,000 document threshold (in our case page 200). 

**Some loopholes discussed with Jon:**
1. There is a loop. Meaning if there are 500,000 documents in total and 50 on each page, there should only be 10,000 pages. However, a user can edit the browser URL and go to page 10,001+ and documents still show. It appears to be a loop. 
2. Need to fix the UI/UX of how the pagination looks at the front end, need to update that regarding the next button and total documents and pages. 